### PR TITLE
Add Coq 8.18.0 as a dependency for Warblre

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -18,7 +18,8 @@
  (name warblre)
  (synopsis "A mechanization of the specification of ECMAScript regexes")
  (depends
-  (ocaml (= 4.14.2))))
+  (ocaml (= 4.14.2))
+  (coq (= 8.18.0))))
 
 (package
  (name warblre-engines)

--- a/warblre.opam
+++ b/warblre.opam
@@ -9,6 +9,7 @@ bug-reports: "https://github.com/epfl-systemf/warblre/issues"
 depends: [
   "dune" {>= "3.14"}
   "ocaml" {= "4.14.2"}
+  "coq" {= "8.18.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Coq was not listed as a dependency for Warblre, implying that following the instructions in README.md did not install Coq.